### PR TITLE
Set up API that can read data on separate schema

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,21 +18,15 @@ class ApplicationController < ActionController::API
 
   def set_schema
     if request.fullpath.match(/^(\/v2)/)
-      Action.table_name = 'apiv2.actions'
-      ActionCategory.table_name = 'apiv2.action_categories'
       Analytic.table_name = 'apiv2.analytics'
       Constituent.table_name = 'apiv2.constituents'
       FundFlow.table_name = 'apiv2.fund_flows'
       Industry.table_name = 'apiv2.industries'
-      User.table_name = 'apiv2.users'
     elsif request.fullpath.match(/^(\/v1)/)
-      Action.table_name = 'api.actions'
-      ActionCategory.table_name = 'api.action_categories'
       Analytic.table_name = 'api.analytics'
       Constituent.table_name = 'api.constituents'
       FundFlow.table_name = 'api.fund_flows'
       Industry.table_name = 'api.industries'
-      User.table_name = 'api.users'
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,14 +4,35 @@ class ApplicationController < ActionController::API
   respond_to :json
 
   before_action :authenticate_user
-   
+  before_action :set_schema
+
   def authenticate_user
     #if request.headers['Authorization'].present?
-    authenticate_or_request_with_http_basic do |username, password|         
+    authenticate_or_request_with_http_basic do |username, password|
       @current_user = User.find_by_username(username)
       if @current_user and @current_user.valid_password?(password)
         sign_in :user, @current_user
       end
+    end
+  end
+
+  def set_schema
+    if request.fullpath.match(/^(\/v2)/)
+      Action.table_name = 'apiv2.actions'
+      ActionCategory.table_name = 'apiv2.action_categories'
+      Analytic.table_name = 'apiv2.analytics'
+      Constituent.table_name = 'apiv2.constituents'
+      FundFlow.table_name = 'apiv2.fund_flows'
+      Industry.table_name = 'apiv2.industries'
+      User.table_name = 'apiv2.users'
+    elsif request.fullpath.match(/^(\/v1)/)
+      Action.table_name = 'api.actions'
+      ActionCategory.table_name = 'api.action_categories'
+      Analytic.table_name = 'api.analytics'
+      Constituent.table_name = 'api.constituents'
+      FundFlow.table_name = 'api.fund_flows'
+      Industry.table_name = 'api.industries'
+      User.table_name = 'api.users'
     end
   end
 

--- a/app/controllers/v2/analytics_controller.rb
+++ b/app/controllers/v2/analytics_controller.rb
@@ -1,0 +1,194 @@
+require 'utilities'
+
+class V2::AnalyticsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :check_permissions
+
+  # /v1/analytics?date=20180509&output=[csv|json]
+  # /v1/analytics?start_date=20180509&end_date=20180520
+  # /api/analytics/:date/getAnalytics
+  # /api/analytics/start_date:end_date/getAnalytics
+  def index
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'analytics')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    set_output_type
+
+    result = []
+    Analytic.where(Utilities.date_clause(params, 'analytics')).find_in_batches do |batch|
+      result += AnalyticSerializer.extract(batch)
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "Analytics #{params[:date]}" : "Analytics #{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/analytics/:fund?date=20180509&output=[csv|json]
+  # /v1/analytics/:fund?start_date=20180509&end_date=20180512
+  # /api/analytics/:date/:fund/getAnalytics
+  # /api/analytics/start_date:end_date/:fund/getAnalytics
+  def show
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'analytics')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    fund = params[:id] || params[:fund]
+    set_output_type
+
+    result = []
+    Analytic.where(Utilities.date_clause(params, 'analytics')).where(:composite_ticker => fund).find_in_batches do |batch|
+      result += AnalyticSerializer.extract(batch)
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "Analytics #{fund}-#{params[:date]}" : "Analytics #{fund}-#{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/analytics/:fund/aggregate?date=20180509&group=asset_class&function=max
+  # /v1/analytics/:fund/aggregate?start_date=20180509&end_date=20180512&group=asset_class&function=max
+  # /api/analytics/:date/:fund/:group/:function/getAggregateFunction
+  # /api/analytics/start_date:end_date/:fund/:group/:function/getAggregateFunction
+  def aggregate
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+    unless params.has_key?(:fund) or params.has_key?(:id)
+      render :json => {:error => 'Ticker required'}, :status => :bad_request and return
+    end
+    unless params.has_key?(:group) and (false == params[:group].blank?)
+      render :json => {:error => I18n.t('valid_group', :groups => Analytic::VALID_GROUPS.join(','))}, :status => :bad_request and return
+    end
+    unless params.has_key?(:function) and Analytic::VALID_FUNCTIONS.include?(params[:function].downcase)
+      render :json => {:error => I18n.t('valid_function', :functions => Analytic::VALID_FUNCTIONS.join(','))}, :status => :bad_request and return
+    end
+
+    # Extract and validate groups
+    groups = []
+    params[:group].downcase.split(/:/).each do |g|
+      sp = spacey_param(g)
+
+      if Analytic::VALID_GROUPS.include?(sp)
+        groups.push(sp)
+      else
+        render :json => {:error => I18n.t('valid_group', :groups => Analytic::VALID_GROUPS.join(','))}, :status => :bad_request and return
+      end
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'analytics')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    # Compute total list of numeric fields (all but the following list)
+    field_list = Analytic.new.attributes
+    ['id', 'run_date', 'composite_ticker', 'quant_grade', 'created_at', 'updated_at'].each do |f|
+      field_list.delete(f)
+    end
+    select_clause = ""
+    field_list.keys.each do |f|
+      select_clause += "," unless select_clause.blank?
+
+      select_clause += "#{params[:function]}(#{f}) AS #{f}"
+    end
+    # Build where
+    fund = params[:id] || params[:fund]
+    where_clause = ""
+    groups.each do |group|
+      where_clause += "OR " unless where_clause.blank?
+
+      where_clause += "#{group} IN (SELECT #{group} FROM industries WHERE composite_ticker='#{fund}') "
+    end
+
+    sql = "SELECT " + select_clause + " FROM analytics WHERE #{Utilities.date_clause(params, 'analytics')} AND composite_ticker in " +
+          "(SELECT composite_ticker FROM industries WHERE (#{where_clause}))"
+
+    render :json => ActiveRecord::Base.connection.execute(sql)
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/analytics/products?date=20180509
+  # /v1/analytics/products?start_date=20180509&end_date=20180512
+  def products
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'analytics')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    render :json => Analytic.where(Utilities.date_clause(params, 'analytics')).order(:composite_ticker).map(&:composite_ticker).uniq
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+private
+  # can be csv or json (default)
+  def set_output_type
+    # downcase will throw if nil; default to json if missing
+    @output_type = params[:output].downcase rescue 'json'
+  end
+
+  # Params like "asset class" might have a space or underscore; normalize to underscore
+  # Also ignore capitalization and remove leading/trailing whitespace
+  def spacey_param(p)
+    p.strip.downcase.gsub(/ /, '_')
+  end
+
+  def check_permissions
+    unless current_user.has_permission(:read_analytics)
+      head :forbidden
+    end
+  end
+end

--- a/app/controllers/v2/constituents_controller.rb
+++ b/app/controllers/v2/constituents_controller.rb
@@ -1,0 +1,164 @@
+require 'utilities'
+
+class V2::ConstituentsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :check_permissions
+
+  # Top constituents
+  TOP_N = 10
+
+  # It's a show because it always selects a fund
+  #   If type and identifier, limit to that; otherwise just return everything for that security and date (range)
+  # /v1/constituents/:fund?date=20180509&output=[csv|json]
+  # /v1/constituents/:fund?start_date=20180509&end_date=20180520&identifier=US912796PG82&type=isin
+  # These can also take a date range
+  # /api/constituent/:type/:date/:fund/getByCusip
+  # /api/constituent/:type/:date/:fund/getByIsin
+  # /api/constituent/:type/:date/:fund/getByFigi
+  # /api/constituent/:type/:date/:fund/getBySedol
+  # /api/constituent/:type/:date/:fund/:identifier/getByCusip
+  # /api/constituent/:type/:date/:fund/:identifier/getByIsin
+  # /api/constituent/:type/:date/:fund/:identifier/getByFigi
+  # /api/constituent/:type/:date/:fund/:identifier/getBySedol
+  def show
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    if params.has_key?(:type)
+      unless ['cusip', 'isin', 'figi', 'sedol'].include?(params[:type].downcase)
+        render :json => {:error => 'Invalid constituent type'}, :status => :bad_request and return
+      end
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'constituents')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    fund = params[:id] || params[:fund]
+    set_output_type
+
+    result = []
+
+    if params.has_key?(:identifier)
+      result += ConstituentSerializer.extract(Constituent.where(Utilities.date_clause(params, 'constituents'))
+                                                         .where(:composite_ticker => fund)
+                                                         .where("#{params[:type].downcase} = '#{params[:identifier]}'"))
+    else
+      Constituent.where(Utilities.date_clause(params, 'constituents')).where(:composite_ticker => fund).find_in_batches do |batch|
+        result += ConstituentSerializer.extract(batch)
+      end
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "Constituents #{fund}-#{params[:date]}" : "Constituents #{fund}-#{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/constituents/products?date=20180509
+  def products
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'constituents')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    render :json => Constituent.where(Utilities.date_clause(params, 'constituents')).order(:composite_ticker).map(&:composite_ticker).uniq
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/constituents/:fund/contents?date=20180509
+  def contents
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'constituents')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    fund = params[:id] || params[:fund]
+
+    render :json => Constituent.where(Utilities.date_clause(params, 'constituents'))
+                               .where(:composite_ticker => fund).order(:constituent_name).map(&:constituent_name).uniq
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/constituents/:fund/top?date=20180509
+  # /api/topconstituents/weight/:date/:fund/getTopConstituents
+  def top
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'constituents')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    fund = params[:id] || params[:fund]
+    set_output_type
+
+    result = ConstituentSerializer.extract(Constituent.where(Utilities.date_clause(params, 'constituents')).where(:composite_ticker => fund ).order('weight DESC').limit(TOP_N))
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "Top Constituents #{fund}-#{params[:date]}" : "Top Constituents #{fund}-#{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+private
+  # can be csv or json (default)
+  def set_output_type
+    # downcase will throw if nil; default to json if missing
+    @output_type = params[:output].downcase rescue 'json'
+  end
+
+  def check_permissions
+    unless current_user.has_permission(:read_constituents)
+      head :forbidden
+    end
+  end
+end

--- a/app/controllers/v2/fundflows_controller.rb
+++ b/app/controllers/v2/fundflows_controller.rb
@@ -1,0 +1,100 @@
+require 'utilities'
+
+class V2::FundflowsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :check_permissions
+
+  # /v1/fundflows?date=20180509&output=[csv|json]
+  # /v1/fundflows?start_date=20180509&end_date=20180509
+  # /api/fundflow/:date/getFundFlow
+  # /api/fundflow/start_date:end_date/getFundFlow
+  def index
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+    set_output_type
+
+    result = []
+    FundFlow.where(Utilities.date_clause(params, 'fundflows')).find_in_batches do |batch|
+      result += FundFlowSerializer.extract(batch)
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "FundFlows #{params[:date]}" : "FundFlows #{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/fundflows/:fund?date=20180509&output=[csv|json]
+  # /v1/fundflows/:fund?start_date=20180509&end_date=20180509
+  # /api/fundflow/:date/:fund/getFundFlow
+  # /api/fundflow/start_date:end_date/:fund/getFundFlow
+  def show
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    fund = params[:id] || params[:fund]
+    set_output_type
+
+    result = []
+    FundFlow.where(Utilities.date_clause(params, 'fundflows')).where(:composite_ticker => fund).find_in_batches do |batch|
+      result += FundFlowSerializer.extract(batch)
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "FundFlows #{fund}-#{params[:date]}" : "FundFlows #{fund}-#{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/fundflows/products?date=20180509
+  # /v1/fundflows/products?start_date=20180509&end_date=20180512
+  def products
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    render :json => FundFlow.where(Utilities.date_clause(params, 'fundflows')).order(:composite_ticker).map(&:composite_ticker).uniq
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+private
+  # can be csv or json (default)
+  def set_output_type
+    # downcase will throw if nil; default to json if missing
+    @output_type = params[:output].downcase rescue 'json'
+  end
+
+  def check_permissions
+    unless current_user.has_permission(:read_fund_flow)
+      head :forbidden
+    end
+  end
+end

--- a/app/controllers/v2/industries_controller.rb
+++ b/app/controllers/v2/industries_controller.rb
@@ -1,0 +1,221 @@
+require 'utilities'
+
+class V2::IndustriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :check_permissions
+
+  # /v1/industries?date=20180509&output=[csv/json] (defaults to json)
+  # /v1/industries?start_date=20180509&end_date=20180509
+  # /api/industry/:date/getIndustry
+  # /api/industry/start_date:end_date/getIndustry
+  def index
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'industries')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    set_output_type
+
+    result = []
+    Industry.where(Utilities.date_clause(params, 'industries')).find_in_batches do |batch|
+      result += IndustrySerializer.extract(batch)
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "Industry #{params[:date]}" : "Industry #{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/industries/:fund?date=20180509&data_type=[csv|json]
+  # /v1/industries/:fund?start_date=20180509&end_date=20180509
+  # /api/industry/:date/:fund/getIndustry
+  # /api/industry/start_date:end_date/:fund/getIndustry
+  def show
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'industries')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    fund = params[:id] || params[:fund]
+    set_output_type
+
+    result = []
+    Industry.where(Utilities.date_clause(params, 'industries')).where(:composite_ticker => fund).find_in_batches do |batch|
+      result += IndustrySerializer.extract(batch)
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "Industry #{fund}-#{params[:date]}" : "Industry #{fund}-#{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /api/industry/csv/:date/:fund/getIndustry
+  # /api/industry/csv/:date/getIndustry
+  def csv
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'industries')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    fund = params[:fund]
+    fname = params.has_key?(:date) ? "Industry #{fund} #{params[:date]}" : "Industry #{fund} #{params[:start_date]}_#{params[:end_date]}"
+
+    result = []
+
+    if fund.nil?
+      # Index
+      Industry.where(Utilities.date_clause(params, 'industries')).find_in_batches do |batch|
+        result += IndustrySerializer.extract(batch)
+      end
+    else
+      # Show
+      fname += "_#{fund}"
+      Industry.where(Utilities.date_clause(params, 'industries')).where(:composite_ticker => fund).find_in_batches do |batch|
+        result += IndustrySerializer.extract(batch)
+      end
+    end
+
+    if result.empty?
+      head :not_found
+    else
+      send_data Utilities.csv_emitter(result),
+                :filename => "#{fname}.csv",
+                :type => "text/csv",
+                :disposition => 'attachment'
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # /v1/industries/:fund/exposures?date=20180509&type=geographic&output=[csv|json]
+  # /v1/industries/:fund/exposures?start_date=20180509&end_date=20180512&type=geographic
+  # /api/industry/exposures/:type/:date/:fund/getIndustryExposures
+  # /api/industry/exposures/:type/start_date:end_date/:fund/getIndustryExposures
+  def exposures
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+    unless params.has_key?(:type) and Industry::VALID_EXPOSURES.include?(params[:type].downcase)
+      render :json => {:error => 'Invalid exposure type'}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'industries')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    fund = params[:id] || params[:fund]
+    set_output_type
+    fieldname = "#{params[:type].downcase}_exposure"
+
+    result = []
+    Industry.where(Utilities.date_clause(params, 'industries'), :composite_ticker => params[:fund])
+            .where("#{fieldname} IS NOT NULL")
+            .pluck(fieldname.to_sym).each do |value|
+              value.split(/;/).sort.each do |country|
+                fields = country.split(/=/)
+                raise "Invalid exposure #{country}" unless 2 == fields.count
+
+                result.push({:name => fields[0], :weight => fields[1]})
+              end
+            end
+
+    if result.empty?
+      head :not_found
+    else
+      if 'csv' == @output_type
+        fname = params.has_key?(:date) ? "Industry #{fieldname}-#{fund}-#{params[:date]}" : "Industry #{fieldname}-#{fund}-#{params[:start_date]}_#{params[:end_date]}"
+        send_data Utilities.csv_emitter(result),
+                  :filename => "#{fname}.csv",
+                  :type => "text/csv",
+                  :disposition => 'attachment'
+      else
+        render :json => result
+      end
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  # This doesn't support output type because it's just a simple list
+  # /v1/industries/products?date=20180509&
+  # /v1/industries/products?start_date=20180509&end_date=20180512
+  def products
+    unless params.has_key?(:date) or (params.has_key?(:start_date) and params.has_key?(:end_date))
+      render :json => {:error => I18n.t('date_required')}, :status => :bad_request and return
+    end
+
+    unless current_user.has_permission(:full_historical)
+      earliest_date = Utilities.earliest_date(params, 'industries')
+      if earliest_date < Utilities::TESTED_DATA_BOUNDARY
+        head :forbidden and return
+      end
+    end
+
+    render :json => Industry.where(Utilities.date_clause(params, 'industries')).order(:composite_ticker).map(&:composite_ticker).uniq
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+private
+  # can be csv or json (default)
+  def set_output_type
+    # downcase will throw if nil; default to json if missing
+    @output_type = params[:output].downcase rescue 'json'
+  end
+
+  def check_permissions
+    unless current_user.has_permission(:read_industry)
+      head :forbidden
+    end
+  end
+end

--- a/app/controllers/v2/users_controller.rb
+++ b/app/controllers/v2/users_controller.rb
@@ -1,0 +1,98 @@
+class V2::UsersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :check_permissions, :except => [:create, :destroy]
+  before_action :check_manage_users, :only => [:create, :destroy]
+
+  def index
+    result = []
+    User.all.each do |u|
+      result.push(get_permissions(u))
+    end
+
+    render :json => result
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  def show
+    user = User.find_by_id(params[:id])
+    if user.nil?
+      head :not_found and return
+    end
+
+    render :json => get_permissions(user).except(:id)
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  def create
+    unless current_user.has_permission(:manage_users)
+      head :forbidden and return
+    end
+
+    u = User.create!(:username => params[:username], :password => params[:password])
+
+    render :json => {:id => u.id}
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  def update
+    user = User.find_by_id(params[:id])
+    if user.nil?
+      head :not_found and return
+    end
+
+    perms = []
+    params[:permissions].each do |p|
+      if Action.descriptions.include?(p)
+        perms.push(p)
+      else
+        raise "Invalid permission: #{p}"
+      end
+    end
+
+    user.actions.delete_all
+    perms.each do |p|
+      user.actions << Action.find_by_description(p)
+    end
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+  def destroy
+    user = User.find_by_id(params[:id])
+    if user.nil?
+      head :not_found and return
+    end
+
+    unless current_user.has_permission(:manage_users)
+      head :forbidden and return
+    end
+
+    user.destroy
+
+    head :ok
+
+  rescue Exception => ex
+    render :json => {:error => ex.message, :trace => ex.backtrace}, :status => :internal_server_error
+  end
+
+private
+  def get_permissions(u)
+    {:id => u.id, :username => u.username, :permissions => u.actions.pluck(:description)}
+  end
+
+  def check_manage_users
+    unless current_user.has_permission(:manage_users)
+      head :forbidden
+    end
+  end
+
+  def check_permissions
+    unless current_user.has_permission(:change_permissions)
+      head :forbidden
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,69 +7,102 @@ Rails.application.routes.draw do
       get 'aggregate', :on => :member
       get 'products', :on => :collection
     end
-    
+
     resources :industries, :only => [:index, :show] do
       get 'exposures', :on => :member
       get 'products', :on => :collection
-    end  
-    
+    end
+
     resources :fundflows, :only => [:index, :show] do
       get 'products', :on => :collection
-    end  
-    
+    end
+
     resources :constituents, :only => [:show] do
       member do
         get 'contents'
         get 'top'
       end
-      
+
       get 'products', :on => :collection
     end
-    
+
     resources :users, :except => [:new, :edit]
   end
 
   namespace :v1 do
     concerns :api_base
   end
-    
+
+  namespace :v2 do
+    concerns :api_base
+  end
+
   # Constituents
 =begin
     # ETP Data - Skipping
-    
+
     $etpdataCollection->setPrefix("/etpdata");
 
     $etpdataCollection->get('/{date}', 'getEtpData');
     $etpdataCollection->get('/', 'getEtpData');
-    
-=end  
+
+=end
 
   # Legacy routes
-  
+
   get '/api/topconstituents/weight/:date/:fund/getTopConstituents', to: 'v1/constituents#top'
-  
-  get '/api/constituent/:type/:date/:fund/:identifier/getByCusip', to: 'v1/constituents#show'  
-  get '/api/constituent/:type/:date/:fund/:identifier/getByIsin', to: 'v1/constituents#show'  
-  get '/api/constituent/:type/:date/:fund/:identifier/getByFigi', to: 'v1/constituents#show'  
-  get '/api/constituent/:type/:date/:fund/:identifier/getBySedol', to: 'v1/constituents#show'  
+
+  get '/api/constituent/:type/:date/:fund/:identifier/getByCusip', to: 'v1/constituents#show'
+  get '/api/constituent/:type/:date/:fund/:identifier/getByIsin', to: 'v1/constituents#show'
+  get '/api/constituent/:type/:date/:fund/:identifier/getByFigi', to: 'v1/constituents#show'
+  get '/api/constituent/:type/:date/:fund/:identifier/getBySedol', to: 'v1/constituents#show'
 
   # :type = cusip/isin/figi/sedol
-  get '/api/constituent/:type/:date/:fund/getByCusip', to: 'v1/constituents#show'  
-  get '/api/constituent/:type/:date/:fund/getByIsin', to: 'v1/constituents#show'  
-  get '/api/constituent/:type/:date/:fund/getByFigi', to: 'v1/constituents#show'  
-  get '/api/constituent/:type/:date/:fund/getBySedol', to: 'v1/constituents#show'  
-  
+  get '/api/constituent/:type/:date/:fund/getByCusip', to: 'v1/constituents#show'
+  get '/api/constituent/:type/:date/:fund/getByIsin', to: 'v1/constituents#show'
+  get '/api/constituent/:type/:date/:fund/getByFigi', to: 'v1/constituents#show'
+  get '/api/constituent/:type/:date/:fund/getBySedol', to: 'v1/constituents#show'
+
   get '/api/fundflow/:date/:fund/getFundFlow', to: 'v1/fundflows#show'
   get '/api/fundflow/:date/getFundFlow', to: 'v1/fundflows#index'
-  
+
   get '/api/industry/csv/:date/:fund/getIndustry', to: 'v1/industries#csv'
   get '/api/industry/csv/:date/getIndustry', to: 'v1/industries#csv'
   get '/api/industry/:date/:fund/getIndustry', to: 'v1/industries#show'
   get '/api/industry/:date/getIndustry', to: 'v1/industries#index'
   get '/api/industry/exposures/:type/:date/:fund/getIndustryExposures', to: 'v1/industries#exposures'
-  
+
   # Analytics
   get '/api/analytics/:date/:fund/:group/:function/getAggregateFunction', to: 'v1/analytics#aggregate'
   get '/api/analytics/:date/:fund/getAnalytics', to: 'v1/analytics#show'
   get '/api/analytics/:date/getAnalytics', to: 'v1/analytics#index'
+
+  # Legacy routes for apiv2
+
+  get '/api/v2/topconstituents/weight/:date/:fund/getTopConstituents', to: 'v2/constituents#top'
+
+  get '/api/v2/constituent/:type/:date/:fund/:identifier/getByCusip', to: 'v2/constituents#show'
+  get '/api/v2/constituent/:type/:date/:fund/:identifier/getByIsin', to: 'v2/constituents#show'
+  get '/api/v2/constituent/:type/:date/:fund/:identifier/getByFigi', to: 'v2/constituents#show'
+  get '/api/v2/constituent/:type/:date/:fund/:identifier/getBySedol', to: 'v2/constituents#show'
+
+  # :type = cusip/isin/figi/sedol
+  get '/api/v2/constituent/:type/:date/:fund/getByCusip', to: 'v2/constituents#show'
+  get '/api/v2/constituent/:type/:date/:fund/getByIsin', to: 'v2/constituents#show'
+  get '/api/v2/constituent/:type/:date/:fund/getByFigi', to: 'v2/constituents#show'
+  get '/api/v2/constituent/:type/:date/:fund/getBySedol', to: 'v2/constituents#show'
+
+  get '/api/v2/fundflow/:date/:fund/getFundFlow', to: 'v2/fundflows#show'
+  get '/api/v2/fundflow/:date/getFundFlow', to: 'v2/fundflows#index'
+
+  get '/api/v2/industry/csv/:date/:fund/getIndustry', to: 'v2/industries#csv'
+  get '/api/v2/industry/csv/:date/getIndustry', to: 'v2/industries#csv'
+  get '/api/v2/industry/:date/:fund/getIndustry', to: 'v2/industries#show'
+  get '/api/v2/industry/:date/getIndustry', to: 'v2/industries#index'
+  get '/api/v2/industry/exposures/:type/:date/:fund/getIndustryExposures', to: 'v2/industries#exposures'
+
+  # Analytics
+  get '/api/v2/analytics/:date/:fund/:group/:function/getAggregateFunction', to: 'v2/analytics#aggregate'
+  get '/api/v2/analytics/:date/:fund/getAnalytics', to: 'v2/analytics#show'
+  get '/api/v2/analytics/:date/getAnalytics', to: 'v2/analytics#index'
 end


### PR DESCRIPTION
As per discussion on Slack with @adanaie .
So we need
- `v1` in `routes.rb` to retrieve data from schema `api`
- `v2` in `routes.rb` to retrieve data from schema `apiv2`

The First problems is I cannot run any api(s) without `rails db:migrate` because it raised migration error. and data structure that I studied from code. 
Also I found that we're using 2 databases on this application? 
because `Action`, `ActionCategory` connect to a database (that using in `database.yml`) and other models connect to EtfgDbBase (that using `etfg_database.yml`)

For my experiment
1. I copied `config/etfg_database.yml` to `config/database.yml` and then configured both files point to my local database. (I have to create 2 schemas manually first)
2. I ran `rails db:setup` 2 times for each schema (controlled by `schema_search_path: <schema_name>`)
3. Copied controller from folder `v1` to `v2` 
4. Create new routes for v2 in `config/routes.rb`
5. Control version and schema in `application_controller.rb`

v1 (blank data in all tables)
![screen shot 2561-11-28 at 16 35 57](https://user-images.githubusercontent.com/24287689/49144882-0fdeb200-f331-11e8-8472-d5ffc520fb5b.png)

v2 (with a `fund_flow` record)
![screen shot 2561-11-28 at 16 35 44](https://user-images.githubusercontent.com/24287689/49144890-13723900-f331-11e8-9e29-15c08031c125.png)

